### PR TITLE
Increase timeout for serpapi response

### DIFF
--- a/jobs/worker/trends_service.py
+++ b/jobs/worker/trends_service.py
@@ -83,7 +83,7 @@ class GoogleTrendsService:
                     "q": keyword,
                     "engine": "google_trends",
                 },
-                timeout=(3, 10),
+                timeout=(3, 40),
             )
             r.raise_for_status()
         except HTTPError:


### PR DESCRIPTION
### Description
- Increases timeout for serpapi response time to 40s

### Testing 
- Passes all tests

<img width="1093" height="539" alt="imagen" src="https://github.com/user-attachments/assets/954afbe2-48ce-4181-96b5-b2394aab014a" />
